### PR TITLE
feat: modernize MotoStix root layout metadata

### DIFF
--- a/motostix/src/app/layout.tsx
+++ b/motostix/src/app/layout.tsx
@@ -1,97 +1,69 @@
 // src/app/layout.tsx
 import type React from "react";
-//import type { Metadata } from "next";
-//import { siteConfig } from "@/config/siteConfig";
+import type { Metadata } from "next";
 
+import { siteConfig } from "@/config/siteConfig";
 import { ClientLayout } from "./client-layout";
 import "./globals.css";
 
-// export const metadata: Metadata = {
-//   // Basic metadata with templates
-//   title: {
-//     default: siteConfig.name,
-//     template: `%s | ${siteConfig.name}`
-//   },
-//   description: siteConfig.description,
-//   keywords: siteConfig.keywords,
+const rawMetadataBase = process.env.NEXT_PUBLIC_APP_URL ?? "/";
+const metadataBase =
+  rawMetadataBase === "/"
+    ? undefined
+    : (() => {
+        try {
+          return new URL(rawMetadataBase);
+        } catch (error) {
+          console.warn("Invalid NEXT_PUBLIC_APP_URL, skipping metadataBase", error);
+          return undefined;
+        }
+      })();
 
-//   // Creator info
-//   authors: [{ name: siteConfig.name, url: siteConfig.url }],
-//   creator: siteConfig.name,
-//   publisher: siteConfig.name,
+const ogImage = process.env.OG_IMAGE_URL ?? siteConfig.ogImage;
 
-//   // Open Graph defaults
-//   openGraph: {
-//     type: "website",
-//     locale: "en_US",
-//     url: siteConfig.url,
-//     siteName: siteConfig.name,
-//     title: {
-//       default: siteConfig.name,
-//       template: `%s | ${siteConfig.name}`
-//     },
-//     description: siteConfig.description,
-//     images: [
-//       {
-//         url: `${siteConfig.url}/og.jpg`,
-//         width: 1200,
-//         height: 630,
-//         alt: `${siteConfig.name} - Premium Custom Stickers`
-//       }
-//     ]
-//   },
-
-//   // Twitter defaults
-//   twitter: {
-//     card: "summary_large_image",
-//     title: {
-//       default: siteConfig.name,
-//       template: `%s | ${siteConfig.name}`
-//     },
-//     description: siteConfig.description,
-//     creator: "@motostix", // Replace with your actual handle
-//     images: [`${siteConfig.url}/og.jpg`]
-//   },
-
-//   // Icons and manifest
-//   icons: {
-//     icon: "/favicon.ico",
-//     shortcut: "/favicon-16x16.png",
-//     apple: "/apple-touch-icon.png"
-//   },
-
-//   // SEO verification (add your actual codes)
-//   verification: {
-//     google: "your-google-verification-code"
-//     // yandex: 'your-yandex-verification-code',
-//     // yahoo: 'your-yahoo-verification-code',
-//   },
-
-//   // Default robots policy
-//   robots: {
-//     index: true,
-//     follow: true,
-//     googleBot: {
-//       index: true,
-//       follow: true,
-//       "max-video-preview": -1,
-//       "max-image-preview": "large",
-//       "max-snippet": -1
-//     }
-//   },
-
-//   // PWA manifest
-//   manifest: `${siteConfig.url}/site.webmanifest`,
-
-//   // Additional metadata
-//   category: "e-commerce",
-//   classification: "Business"
-// };
+export const metadata: Metadata = {
+  // ✅ Site-wide defaults belong here. Use export const metadata or generateMetadata inside a page/route to override per-view values.
+  title: {
+    default: siteConfig.name,
+    template: `%s | ${siteConfig.name}`
+  },
+  description: siteConfig.description,
+  metadataBase,
+  openGraph: {
+    title: siteConfig.name,
+    description: siteConfig.description,
+    url: siteConfig.url,
+    siteName: siteConfig.name,
+    images: ogImage
+      ? [
+          {
+            url: ogImage,
+            width: 1200,
+            height: 630,
+            alt: siteConfig.name
+          }
+        ]
+      : undefined,
+    type: "website"
+  },
+  twitter: {
+    card: "summary_large_image",
+    site: siteConfig.twitter || undefined,
+    title: siteConfig.name,
+    description: siteConfig.description,
+    images: ogImage ? [ogImage] : undefined
+  },
+  icons: {
+    icon: "/favicon.ico",
+    shortcut: "/favicon-16x16.png",
+    apple: "/apple-touch-icon.png"
+  }
+};
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className="relative ">
+      <body className="relative">
         <ClientLayout>{children}</ClientLayout>
       </body>
     </html>


### PR DESCRIPTION
## Summary
- implement Next.js App Router metadata defaults for MotoStix using site configuration and environment fallbacks
- keep the client provider stack encapsulated in ClientLayout while cleaning the root html/body structure

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e18681ec8c8324ad7f8e39ce1b08b1