### PR TITLE
feat: centralize site metadata helpers

### DIFF
--- a/motostix/src/app/layout.tsx
+++ b/motostix/src/app/layout.tsx
@@ -2,68 +2,38 @@
 import type React from "react";
 import type { Metadata } from "next";
 
-import { siteConfig } from "@/config/siteConfig";
+import { baseMetadata } from "@/lib/seo";
+import { siteConfig } from "@/lib/siteConfig";
 import { ClientLayout } from "./client-layout";
 import "./globals.css";
 
-const rawMetadataBase = process.env.NEXT_PUBLIC_APP_URL ?? "/";
-const metadataBase =
-  rawMetadataBase === "/"
-    ? undefined
-    : (() => {
-        try {
-          return new URL(rawMetadataBase);
-        } catch (error) {
-          console.warn("Invalid NEXT_PUBLIC_APP_URL, skipping metadataBase", error);
-          return undefined;
-        }
-      })();
-
-const ogImage = process.env.OG_IMAGE_URL ?? siteConfig.ogImage;
-
-export const metadata: Metadata = {
-  // ✅ Site-wide defaults belong here. Use export const metadata or generateMetadata inside a page/route to override per-view values.
-  title: {
-    default: siteConfig.name,
-    template: `%s | ${siteConfig.name}`
-  },
-  description: siteConfig.description,
-  metadataBase,
-  openGraph: {
-    title: siteConfig.name,
-    description: siteConfig.description,
-    url: siteConfig.url,
-    siteName: siteConfig.name,
-    images: ogImage
-      ? [
-          {
-            url: ogImage,
-            width: 1200,
-            height: 630,
-            alt: siteConfig.name
-          }
-        ]
-      : undefined,
-    type: "website"
-  },
-  twitter: {
-    card: "summary_large_image",
-    site: siteConfig.twitter || undefined,
-    title: siteConfig.name,
-    description: siteConfig.description,
-    images: ogImage ? [ogImage] : undefined
-  },
-  icons: {
-    icon: "/favicon.ico",
-    shortcut: "/favicon-16x16.png",
-    apple: "/apple-touch-icon.png"
-  }
-};
+export const metadata: Metadata = baseMetadata();
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className="relative">
+      <body className="relative" data-site-name={siteConfig.name}>
+        {/**
+         * Example header using the shared navigation config if you ever need to render
+         * it here instead of inside <ClientLayout />:
+         * <header>
+         *   <nav>
+         *     <ul className="flex gap-4">
+         *       {siteConfig.nav.map((item) => (
+         *         <li key={item.href}>
+         *           <a
+         *             href={item.href}
+         *             target={item.external ? "_blank" : undefined}
+         *             rel={item.external ? "noreferrer" : undefined}
+         *           >
+         *             {item.label}
+         *           </a>
+         *         </li>
+         *       ))}
+         *     </ul>
+         *   </nav>
+         * </header>
+         */}
         <ClientLayout>{children}</ClientLayout>
       </body>
     </html>

--- a/motostix/src/config/siteConfig.ts
+++ b/motostix/src/config/siteConfig.ts
@@ -1,16 +1,4 @@
 // src/config/siteConfig.ts
-
-const isDev = process.env.NODE_ENV === "development";
-
-const SITE_URL = process.env.SITE_URL || (isDev ? "http://localhost:3000" : "https://motostix.com");
-const OG_IMAGE_URL = process.env.OG_IMAGE_URL || (isDev ? `${SITE_URL}/og.jpg` : "https://motostix.com/og.jpg");
-const SITE_TWITTER = process.env.SITE_TWITTER || (isDev ? "https://twitter.com/example" : "");
-
-export const siteConfig = {
-  name: "MotoStix",
-  url: SITE_URL,
-  ogImage: OG_IMAGE_URL,
-  description: "High-quality custom stickers for any surface or occasion.",
-  keywords: ["custom stickers", "vinyl stickers", "waterproof stickers", "decals", "labels"],
-  twitter: SITE_TWITTER
-};
+// Re-exported for backward compatibility. Prefer importing from "@/lib/siteConfig".
+export type { NavItem, SiteConfig } from "@/lib/siteConfig";
+export { siteConfig } from "@/lib/siteConfig";

--- a/motostix/src/lib/seo.ts
+++ b/motostix/src/lib/seo.ts
@@ -1,0 +1,58 @@
+import type { Metadata } from "next";
+
+import { siteConfig } from "./siteConfig";
+
+export function baseMetadata(): Metadata {
+  const url = new URL(siteConfig.url);
+
+  return {
+    metadataBase: url,
+    title: {
+      default: siteConfig.name,
+      template: `%s · ${siteConfig.name}`
+    },
+    description: siteConfig.description,
+    openGraph: {
+      type: "website",
+      url: siteConfig.url,
+      siteName: siteConfig.name,
+      title: siteConfig.name,
+      description: siteConfig.description,
+      images: [{ url: siteConfig.ogImage }]
+    },
+    twitter: {
+      card: "summary_large_image",
+      site: siteConfig.twitter,
+      title: siteConfig.name,
+      description: siteConfig.description,
+      images: [siteConfig.ogImage]
+    },
+    alternates: {
+      canonical: siteConfig.url
+    },
+    icons: { icon: "/favicon.ico", shortcut: "/favicon.ico" }
+  };
+}
+
+/** Convenience for pages that want to override title/description/og */
+export function pageMetadata(opts: {
+  title?: string;
+  description?: string;
+  path?: string; // e.g. "/products/helmets"
+  image?: string;
+}): Metadata {
+  const base = baseMetadata();
+  const url = opts.path ? new URL(opts.path, siteConfig.url).toString() : siteConfig.url;
+  const title = opts.title ?? base.title;
+  const description = opts.description ?? siteConfig.description;
+  const image = opts.image ?? siteConfig.ogImage;
+
+  return {
+    ...base,
+    title,
+    description,
+    openGraph: { ...base.openGraph, url, title, description, images: [{ url: image }] },
+    twitter: { ...base.twitter, title, description, images: [image] },
+    alternates: { canonical: url }
+  };
+}

--- a/motostix/src/lib/siteConfig.ts
+++ b/motostix/src/lib/siteConfig.ts
@@ -1,0 +1,39 @@
+export type NavItem = {
+  /** Display text for the navigation link. */
+  label: string;
+  /** Destination URL or pathname. */
+  href: string;
+  /** Whether the link should open externally. */
+  external?: boolean;
+};
+
+export const siteConfig = {
+  /** Brand name used across metadata and UI. */
+  name: "MotoStix",
+  /** Default description for search engines and previews. */
+  description: "High-quality vehicle stickers and accessories.",
+  /** Primary site URL, configurable via environment variable. */
+  url: process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000",
+  /** Default Open Graph image URL. */
+  ogImage: process.env.OG_IMAGE_URL ?? "/og.jpg",
+  /** Twitter handle for card previews. */
+  twitter: process.env.SITE_TWITTER ?? "@motostix",
+  /** Commonly used external and internal links. */
+  links: {
+    /** GitHub repository link. */
+    github: "https://github.com/raymondoh/motostix",
+    /** Twitter profile link. */
+    twitter: "https://twitter.com/motostix",
+    /** Contact page link. */
+    contact: "/contact"
+  },
+  /** Primary navigation items displayed in the header. */
+  nav: [
+    { label: "Home", href: "/" },
+    { label: "Products", href: "/products" },
+    { label: "About", href: "/about" },
+    { label: "Contact", href: "/contact" }
+  ] satisfies NavItem[]
+} as const;
+
+export type SiteConfig = typeof siteConfig;


### PR DESCRIPTION
## Summary
- add a typed site configuration that captures shared branding, links, and navigation data
- provide reusable App Router metadata helpers for global defaults and per-page overrides
- update the root layout to consume the new helpers and document how to access the shared nav config

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e195aa6d5083249bc7c7cc33cff900