### PR TITLE
docs: refresh environment setup instructions

### DIFF
--- a/motostix/.env.example
+++ b/motostix/.env.example
@@ -1,46 +1,91 @@
-# Client environment variables
-## Site / URLs
-NEXT_PUBLIC_APP_URL="https://motostix.example.com"
+# Copy this file to .env.local (or .env.production) and fill in the secrets for each environment.
+#   cp .env.example .env.local
 
-## Stripe (client)
-NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="pk_live_your_publishable_key"
+#############################
+# Client environment (NEXT_PUBLIC_*)
+#############################
+# Public base URL for the app (http://localhost:3000 for local dev).
+NEXT_PUBLIC_APP_URL=
+# Stripe publishable key used by the client (pk_test_* in dev, pk_live_* in prod).
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
+# Firebase web API key from Project Settings > General.
+NEXT_PUBLIC_FIREBASE_API_KEY=
+# Firebase auth domain (usually <project>.firebaseapp.com).
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=
+# Firebase project ID shared by client and server SDKs.
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=
+# Firebase storage bucket used for uploads (e.g. <project>.appspot.com).
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=
+# Firebase Cloud Messaging sender ID (numeric string from Firebase console).
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=
+# Firebase web app ID (looks like 1:1234567890:web:abcdef).
+NEXT_PUBLIC_FIREBASE_APP_ID=
 
-## Firebase (client)
-NEXT_PUBLIC_FIREBASE_API_KEY="your_firebase_api_key"
-NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN="your-project.firebaseapp.com"
-NEXT_PUBLIC_FIREBASE_PROJECT_ID="your-project-id"
-NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET="your-project.appspot.com"
-NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID="000000000000"
-NEXT_PUBLIC_FIREBASE_APP_ID="1:000000000000:web:example"
+#############################
+# Server environment (never expose to the client)
+#############################
+# Stripe secret API key for privileged server calls (sk_test_* in dev).
+STRIPE_SECRET_KEY=
+# Stripe webhook signing secret from `stripe listen` or dashboard.
+STRIPE_WEBHOOK_SECRET=
+# Firebase project ID for Admin SDK configuration (matches client project ID).
+FIREBASE_PROJECT_ID=
+# Firebase service account email from the Admin SDK JSON key.
+FIREBASE_CLIENT_EMAIL=
+# Firebase Admin private key; keep newline escapes as \n when storing in env files.
+# Example: -----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n
+FIREBASE_PRIVATE_KEY=
+# Firebase storage bucket used by Admin SDK (e.g. <project>.appspot.com).
+FIREBASE_STORAGE_BUCKET=
+# Google OAuth client ID for NextAuth (from Google Cloud console).
+AUTH_GOOGLE_CLIENT_ID=
+# Google OAuth client secret for NextAuth.
+AUTH_GOOGLE_CLIENT_SECRET=
+# Resend API key for transactional emails (RESEND_API_KEY from dashboard).
+RESEND_API_KEY=
+# Mailchimp API key for marketing emails.
+MAILCHIMP_API_KEY=
+# Mailchimp data center prefix (e.g. us21 from your API key suffix).
+MAILCHIMP_SERVER_PREFIX=
+# Mailchimp audience/list ID where subscribers should be added.
+MAILCHIMP_AUDIENCE_ID=
+# Canonical site URL for SEO metadata (https://your-domain.com in production).
+SITE_URL=
+# Default Open Graph image URL used for social previews.
+OG_IMAGE_URL=
+# Twitter/X handle (with @) used in social metadata.
+SITE_TWITTER=
 
-# Server environment variables
-## Stripe (server)
-STRIPE_SECRET_KEY="sk_live_your_secret_key"
-STRIPE_WEBHOOK_SECRET="whsec_your_webhook_secret"
+#############################
+# Optional integrations
+#############################
+# Uncomment if using Upstash Redis for caching/queues.
+# UPSTASH_REDIS_REST_URL=
+# UPSTASH_REDIS_REST_TOKEN=
 
-## Firebase Admin (server)
-FIREBASE_PROJECT_ID="your-project-id"
-FIREBASE_CLIENT_EMAIL="service-account@your-project.iam.gserviceaccount.com"
-FIREBASE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\\nYOUR_KEY\\n-----END PRIVATE KEY-----\\n"
-FIREBASE_STORAGE_BUCKET="your-project.appspot.com"
-
-## NextAuth / Google OAuth
-AUTH_GOOGLE_CLIENT_ID="your-google-client-id"
-AUTH_GOOGLE_CLIENT_SECRET="your-google-client-secret"
-
-## Resend
-RESEND_API_KEY="your-resend-api-key"
-
-## Mailchimp
-MAILCHIMP_API_KEY="your-mailchimp-api-key"
-MAILCHIMP_SERVER_PREFIX="us1"
-MAILCHIMP_AUDIENCE_ID="your-mailchimp-audience-id"
-
-## Upstash Redis (optional)
-UPSTASH_REDIS_REST_URL="https://your-upstash-rest-url"
-UPSTASH_REDIS_REST_TOKEN="your-upstash-rest-token"
-
-## Site / SEO (optional)
-SITE_URL="https://motostix.example.com"
-OG_IMAGE_URL="https://motostix.example.com/og-image.png"
-SITE_TWITTER="@motostix"
+#############################
+# Local development defaults (copy/paste as needed)
+#############################
+# NEXT_PUBLIC_APP_URL="http://localhost:3000"
+# NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="pk_test_placeholder"
+# NEXT_PUBLIC_FIREBASE_API_KEY="firebase_test_api_key"
+# NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN="motostix-dev.firebaseapp.com"
+# NEXT_PUBLIC_FIREBASE_PROJECT_ID="motostix-dev"
+# NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET="motostix-dev.appspot.com"
+# NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID="000000000000"
+# NEXT_PUBLIC_FIREBASE_APP_ID="1:000000000000:web:abcdef123456"
+# STRIPE_SECRET_KEY="sk_test_placeholder"
+# STRIPE_WEBHOOK_SECRET="whsec_placeholder"
+# FIREBASE_PROJECT_ID="motostix-dev"
+# FIREBASE_CLIENT_EMAIL="firebase-adminsdk@motostix-dev.iam.gserviceaccount.com"
+# FIREBASE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nDEV_KEY\n-----END PRIVATE KEY-----\n"
+# FIREBASE_STORAGE_BUCKET="motostix-dev.appspot.com"
+# AUTH_GOOGLE_CLIENT_ID="your-google-client-id.apps.googleusercontent.com"
+# AUTH_GOOGLE_CLIENT_SECRET="your-google-client-secret"
+# RESEND_API_KEY="re_1234567890"
+# MAILCHIMP_API_KEY="mailchimp-us21-1234567890"
+# MAILCHIMP_SERVER_PREFIX="us21"
+# MAILCHIMP_AUDIENCE_ID="0000000000"
+# SITE_URL="http://localhost:3000"
+# OG_IMAGE_URL="http://localhost:3000/og.png"
+# SITE_TWITTER="@motostix"


### PR DESCRIPTION
## Summary
- regenerate `.env.example` with grouped client and server variables, inline documentation, and local development defaults
- expand the README with environment variable guidance plus Firebase emulator, Stripe webhook, and email provider setup notes

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68e1998c9d608324a5c78491102cbef0